### PR TITLE
[Enhancement] FeralSpirit LastCastTime fix

### DIFF
--- a/AethysRotation_Shaman/AethysRotation_Shaman.toc
+++ b/AethysRotation_Shaman/AethysRotation_Shaman.toc
@@ -10,3 +10,4 @@
 
 Settings.lua
 Enhancement.lua
+Events.lua

--- a/AethysRotation_Shaman/Events.lua
+++ b/AethysRotation_Shaman/Events.lua
@@ -1,0 +1,89 @@
+--- ============================ HEADER ============================
+--- ======= LOCALIZE =======
+  -- Addon
+  local addonName, addonTable = ...;
+  -- AethysCore
+  local AC = AethysCore;
+  local Cache = AethysCache;
+  local Unit = AC.Unit;
+  local Player = Unit.Player;
+  local Target = Unit.Target;
+  local Spell = AC.Spell;
+  local Item = AC.Item;
+  -- Lua
+  local select = select;
+  -- File Locals
+
+
+
+--- ============================ CONTENT ============================
+--- ======= NON-COMBATLOG =======
+
+
+--- ======= COMBATLOG =======
+  --- Combat Log Arguments
+    ------- Base -------
+      --     1        2         3           4           5           6              7             8         9        10           11
+      -- TimeStamp, Event, HideCaster, SourceGUID, SourceName, SourceFlags, SourceRaidFlags, DestGUID, DestName, DestFlags, DestRaidFlags
+
+    ------- Prefixes -------
+      --- SWING
+      -- N/A
+
+      --- SPELL & SPELL_PACIODIC
+      --    12        13          14
+      -- SpellID, SpellName, SpellSchool
+
+    ------- Suffixes -------
+      --- _CAST_START & _CAST_SUCCESS & _SUMMON & _RESURRECT
+      -- N/A
+
+      --- _CAST_FAILED
+      --     15
+      -- FailedType
+
+      --- _AURA_APPLIED & _AURA_REMOVED & _AURA_REFRESH
+      --    15
+      -- AuraType
+
+      --- _AURA_APPLIED_DOSE
+      --    15       16
+      -- AuraType, Charges
+
+      --- _INTERRUPT
+      --      15            16             17
+      -- ExtraSpellID, ExtraSpellName, ExtraSchool
+
+      --- _HEAL
+      --   15         16         17        18
+      -- Amount, Overhealing, Absorbed, Critical
+
+      --- _DAMAGE
+      --   15       16       17       18        19       20        21        22        23
+      -- Amount, Overkill, School, Resisted, Blocked, Absorbed, Critical, Glancing, Crushing
+
+      --- _MISSED
+      --    15        16           17
+      -- MissType, IsOffHand, AmountMissed
+
+    ------- Special -------
+      --- UNIT_DIED, UNIT_DESTROYED
+      -- N/A
+
+  --- End Combat Log Arguments
+
+  -- Arguments Variables
+  local SpellID;
+
+  --- Set LastCastTimes
+    AC:RegisterForSelfCombatEvent(
+      function (...)
+          SpellID = select(12, ...);
+
+          -- Feral Spirit
+          if SpellID == Spell.Shaman.Enhancement.FeralSpirit:ID() then
+            Spell.Shaman.Enhancement.FeralSpirit.LastCastTime = AC.GetTime();
+          end
+      end
+      , "SPELL_CAST_SUCCESS"
+    );


### PR DESCRIPTION
This makes Crash Lightning work as it should.
The LastCastTime wasn't being updated for FeralSpirit.