### PR TITLE
Blood DK Tweaks

### DIFF
--- a/AethysRotation_DeathKnight/Blood.lua
+++ b/AethysRotation_DeathKnight/Blood.lua
@@ -50,7 +50,8 @@
   -- GUI Settings
   local Settings = {
    General = AR.GUISettings.General,
-   DeathKnight = AR.GUISettings.APL.DeathKnight
+    Commons = AR.GUISettings.APL.DeathKnight.Commons,
+    Blood = AR.GUISettings.APL.DeathKnight.Blood
  };
 
 
@@ -130,14 +131,15 @@ local function IcyVeinsRotation()
 		if AR.Cast(S.BloodBoil) then return ""; end
 	end
 
-	if AR.CDsON() and S.BoneStorm:IsUsable() and Cache.EnemiesCount[10] >= 1 and Player:RunicPower() >= 100 then
+	if AR.CDsON() and S.BoneStorm:IsCastable() and Cache.EnemiesCount[10] >= 1 and Player:RunicPower() >= 100 then
 	    if AR.Cast(S.BoneStorm, Settings.Blood.GCDasOffGCD.BoneStorm) then return ""; end
+	end
 	
 	if S.DeathandDecay:IsUsable() and (Cache.EnemiesCount[10] == 1 and Player:Buff(S.CrimsonScourge) and S.RapidDecomposition:IsAvailable()) or (Cache.EnemiesCount[10] > 1 and Player:Buff(S.CrimsonScourge)) then
 		if AR.Cast(S.DeathandDecay) then return ""; end
 	end
 
-	if S.BloodDrinker:IsCastable() and S.BloodDrinker:IsAvailable() and not Player:Buff(S.DancingRuneWeaponBuff) and Player:RunicPowerDeficit() >= 10 then
+	if S.BloodDrinker:IsCastable() and S.BloodDrinker:IsLearned() and not Player:Buff(S.DancingRuneWeaponBuff) and Player:RunicPowerDeficit() >= 10 then
 		if AR.Cast(S.BloodDrinker, Settings.Blood.GCDasOffGCD.BloodDrinker) then return ""; end
 	end
 	
@@ -151,6 +153,7 @@ local function IcyVeinsRotation()
 	
 	if S.DeathStrike:IsUsable() and S.Marrowrend:IsCastable() and Player:BuffStack(S.BoneShield) <= 6 then
 	    if AR.Cast(S.DeathStrike) then return ""; end
+	end
 
 	if S.DeathandDecay:IsUsable() and ((Cache.EnemiesCount[10] == 1 and Player:Runes() >= 3 and S.RapidDecomposition:IsAvailable() and S.DeathandDecay:CooldownRemains() == 0)  or (Cache.EnemiesCount[10] >= 3 and S.DeathandDecay:CooldownRemains() == 0)) and Player:RunicPowerDeficit() >= 10 then
 		if AR.Cast(S.DeathandDecay) then return ""; end
@@ -161,7 +164,7 @@ local function IcyVeinsRotation()
 		if AR.Cast(S.DeathStrike) then return ""; end
 	end--]]
 
-	if S.HeartStrike:IsCastable() and ((Player:RuneTimeToX(3) <= Player:GCD()) or Player:Runes() >=3) and (S.HeartBreaker:IsAvailable() and Player.RunicPowerDeficit() >= 15 or Player.RunicPowerDeficit() >= (15 + 2 * math.min(Cache:EnemiesCount[10], 5))) then
+	if S.HeartStrike:IsCastable() and ((Player:RuneTimeToX(3) <= Player:GCD()) or Player:Runes() >=3) and (S.HeartBreaker:IsAvailable() and Player:RunicPowerDeficit() >= 15 or Player:RunicPowerDeficit() >= (15 + 2 * math.min(Cache.EnemiesCount[10], 5))) then
 		if AR.Cast(S.HeartStrike) then return ""; end
 	end
 
@@ -189,11 +192,11 @@ end
 local function APL ()
     -- Unit Update
     AC.GetEnemies(10);
-    AC.GetEnemies(20);
+    AC.GetEnemies(20)
 
    -- In Combat
     if Everyone.TargetIsValid() and Target:IsInRange(20) then
-    	if Settings.DeathKnight.Blood.useIcyVeinsRotation then
+    	if Settings.Blood.useIcyVeinsRotation then
 			ShouldReturn = IcyVeinsRotation();
 		else 
 			ShouldReturn = SingleTarget();

--- a/AethysRotation_DeathKnight/Blood.lua
+++ b/AethysRotation_DeathKnight/Blood.lua
@@ -41,7 +41,8 @@
   RapidDecomposition			= Spell(194662),
   Ossuary						= Spell(219786),
   HeartStrike					= Spell(206930),
-  BloodBoil						= Spell(50842)
+  BloodBoil						= Spell(50842),
+  HeartBreaker                  = Spell(221536),
 
 };
   local S = Spell.DeathKnight.Blood;
@@ -117,11 +118,11 @@ local function SingleTarget()
 end
 local function IcyVeinsRotation()
 
-	if S.DancingRuneWeapon:IsCastable() then
-		if AR.Cast(S.DancingRuneWeapon) then return ""; end
+	if AR.CDsON() and S.DancingRuneWeapon:IsCastable() then
+		if AR.Cast(S.DancingRuneWeapon, Settings.Blood.OffGCDasOffGCD.DancingRuneWeapon) then return ""; end
 	end
 
-	if S.Marrowrend:IsCastable() and Player:BuffRemains(S.BoneShield) <= 3 then
+	if S.Marrowrend:IsCastable() and Player:BuffRemains(S.BoneShield) <= (Player:GCD() * 2) then
 		if AR.Cast(S.Marrowrend) then return ""; end
 	end
 
@@ -129,23 +130,29 @@ local function IcyVeinsRotation()
 		if AR.Cast(S.BloodBoil) then return ""; end
 	end
 
+	if AR.CDsON() and S.BoneStorm:IsUsable() and Cache.EnemiesCount[10] >= 1 and Player:RunicPower() >= 100 then
+	    if AR.Cast(S.BoneStorm, Settings.Blood.GCDasOffGCD.BoneStorm) then return ""; end
+	
 	if S.DeathandDecay:IsUsable() and (Cache.EnemiesCount[10] == 1 and Player:Buff(S.CrimsonScourge) and S.RapidDecomposition:IsAvailable()) or (Cache.EnemiesCount[10] > 1 and Player:Buff(S.CrimsonScourge)) then
 		if AR.Cast(S.DeathandDecay) then return ""; end
 	end
 
-	if S.DeathStrike:IsUsable() and Player:RunicPowerDeficit() <= 20 then
-		if AR.Cast(S.DeathStrike) then return ""; end
+	if S.BloodDrinker:IsCastable() and S.BloodDrinker:IsAvailable() and not Player:Buff(S.DancingRuneWeaponBuff) and Player:RunicPowerDeficit() >= 10 then
+		if AR.Cast(S.BloodDrinker, Settings.Blood.GCDasOffGCD.BloodDrinker) then return ""; end
 	end
+	
+	if S.DeathStrike:IsUsable() and S.BloodDrinker:IsCastable() and (S.BloodDrinker:IsAvailable() or S.BloodDrinker:CooldownRemains() <= Player:GCD()) and not Player:Buff(S.DancingRuneWeaponBuff) and ((Player:RuneTimeToX(1) <= Player:GCD()) or Player:Runes() >= 1) then
+	    if AR.Cast(S.DeathStrike) then return ""; end
+    end
 
-	if S.BloodDrinker:IsCastable() and S.BloodDrinker:IsAvailable() and not Player:Buff(S.DancingRuneWeaponBuff) then
-		if AR.Cast(S.BloodDrinker) then return ""; end
-	end
-
-	if S.Marrowrend:IsCastable() and (Player:BuffStack(S.BoneShield) < 5 and S.Ossuary:IsAvailable()) or (Player:BuffStack(S.BoneShield) <= 6) then
+	if S.Marrowrend:IsCastable() and Player:BuffStack(S.BoneShield) <= 6 and Player:RunicPowerDeficit() >= 20 then
 		if AR.Cast(S.Marrowrend) then return ""; end
 	end
+	
+	if S.DeathStrike:IsUsable() and S.Marrowrend:IsCastable() and Player:BuffStack(S.BoneShield) <= 6 then
+	    if AR.Cast(S.DeathStrike) then return ""; end
 
-	if S.DeathandDecay:IsUsable() and (Cache.EnemiesCount[10] == 1 and Player:Runes() >= 3 and S.RapidDecomposition:IsAvailable() and S.DeathandDecay:CooldownRemains() == 0)  or (Cache.EnemiesCount[10] >= 3 and S.DeathandDecay:CooldownRemains() == 0) then
+	if S.DeathandDecay:IsUsable() and ((Cache.EnemiesCount[10] == 1 and Player:Runes() >= 3 and S.RapidDecomposition:IsAvailable() and S.DeathandDecay:CooldownRemains() == 0)  or (Cache.EnemiesCount[10] >= 3 and S.DeathandDecay:CooldownRemains() == 0)) and Player:RunicPowerDeficit() >= 10 then
 		if AR.Cast(S.DeathandDecay) then return ""; end
 	end
 
@@ -154,8 +161,13 @@ local function IcyVeinsRotation()
 		if AR.Cast(S.DeathStrike) then return ""; end
 	end--]]
 
-	if S.HeartStrike:IsCastable() and (Player:RuneTimeToX(3) <= Player:GCD()) or Player:Runes() >=3 then
+	if S.HeartStrike:IsCastable() and ((Player:RuneTimeToX(3) <= Player:GCD()) or Player:Runes() >=3) and (S.HeartBreaker:IsAvailable() and Player.RunicPowerDeficit() >= 15 or Player.RunicPowerDeficit() >= (15 + 2 * math.min(Cache:EnemiesCount[10], 5))) then
 		if AR.Cast(S.HeartStrike) then return ""; end
+	end
+
+	--- Move this below builders and replace the RunicPowerDeficit conditional with one that says 3+ runes available.
+	if S.DeathStrike:IsUsable() and (Player:RuneTimeToX(3) <= Player:GCD() or Player:Runes() >= 3) then
+		if AR.Cast(S.DeathStrike) then return ""; end
 	end
 
 	if S.DeathandDecay:IsUsable() and Player:Buff(S.CrimsonScourge) and not S.RapidDecomposition:IsAvailable() then

--- a/AethysRotation_DeathKnight/Settings.lua
+++ b/AethysRotation_DeathKnight/Settings.lua
@@ -72,11 +72,12 @@
      -- {Display GCD as OffGCD, ForceReturn}
       GCDasOffGCD = {
         -- Abilities
-      
+        BloodDrinker = {true, false},
+	    BoneStorm = {true, false},
       },
       -- {Display OffGCD as OffGCD, ForceReturn}
       OffGCDasOffGCD = {
-
+        DancingRuneWeapon = {true, false},
        }
    },  
   
@@ -108,3 +109,6 @@
   CreateARPanelOption("OffGCDasOffGCD", CP_Frost, "APL.DeathKnight.Frost.OffGCDasOffGCD.EmpowerRuneWeapon", "Empower Rune Weapon", "Enable if you want to put Empower Rune Weapon shown as Off GCD (top icons) instead of Main.");
   --Blood Panels
   CreatePanelOption("CheckButton", CP_Blood, "APL.DeathKnight.Blood.useIcyVeinsRotation", "Show the IcyVeins Rotation instead of the one from Simulationcraft");
+  CreateARPanelOption("GCDasOffGCD", CP_Blood, "APL.DeathKnight.Blood.GCDasOffGCD.BloodDrinker", "Blooddrinker", "Enable if you want to put Blooddrinker shown as Off GCD (top icons) instead of Main.");
+  CreateARPanelOption("GCDasOffGCD", CP_Blood, "APL.DeathKnight.Blood.GCDasOffGCD.BoneStorm", "Bonestorm", "Enable if you want to put Bonestorm shown as Off GCD (top icons) instead of Main.");
+  CreateARPanelOption("OffGCDasOffGCD", CP_Blood, "APL.DeathKnight.Blood.OffGCDasOffGCD.DancingRuneWeapon", "Dancing Rune Weapon", "Enable if you want to put Dancing Rune Weapon shown as Off GCD (top icons) instead of Main.");


### PR DESCRIPTION
Added CD and OffGCD Support for Blood DK (currently, only the Icy Veins rotation implements this.)
Flagged the Icy Veins rotation as the default Blood rotation (until we can update the implementation of the SimC APL rotation.)
Updated Blood DK Icy Veins rotation:
Moved Death Strike around to allow for dynamic determination of when to dump RP to avoid RP capping
Tweaked the conditionals for Marrowrend usage
Updated some chained booleans to conform to lua order of operations
Added support for Bonestorm to the Icy Veins rotation