### PR TITLE
 Moved Settings to GUI, Fel Rush as Suggestion

### DIFF
--- a/AethysRotation_DemonHunter/Havoc.lua
+++ b/AethysRotation_DemonHunter/Havoc.lua
@@ -262,7 +262,7 @@ local function APL()
     end
     -- fel_rush,if=!talent.momentum.enabled&(buff.metamorphosis.down|talent.demon_blades.enabled)&(charges=2|(raid_event.movement.in>10&raid_event.adds.in>10))
     if S.FelRush:IsCastable(20, true) and (not S.Momentum:IsAvailable() and (Player:BuffDownP(S.MetamorphosisBuff) or S.DemonBlades:IsAvailable())) then
-      if AR.Cast(S.FelRush) then return ""; end
+      if AR.CastSuggested(S.FelRush) then return ""; end
     end
     -- demons_bite
     if InMeleeRange and S.DemonsBite:IsCastable() then
@@ -274,7 +274,7 @@ local function APL()
     end
     -- fel_rush,if=movement.distance>15|(buff.out_of_range.up&!talent.momentum.enabled)
     if S.FelRush:IsCastable(20) and (not IsInMeleeRange() and not S.Momentum:IsAvailable()) then
-      if AR.Cast(S.FelRush) then return ""; end
+      if AR.CastSuggested(S.FelRush) then return ""; end
     end
   end
 
@@ -313,7 +313,7 @@ local function APL()
     -- fel_rush,if=charges=2&!talent.momentum.enabled&!talent.fel_mastery.enabled&!buff.metamorphosis.up
     if S.FelRush:IsCastable(20, true)
       and (S.FelRush:ChargesP() == 2 and not S.Momentum:IsAvailable() and not S.FelMastery:IsAvailable() and not Player:BuffP(S.MetamorphosisBuff)) then
-      if AR.Cast(S.FelRush) then return "FR Capped"; end
+      if AR.CastSuggested(S.FelRush) then return "FR Capped"; end
     end
     -- fel_eruption
     if S.FelEruption:IsCastable(20) and Player:Fury() > S.FelEruption:Cost() then
@@ -369,7 +369,7 @@ local function APL()
     end
     -- fel_rush,if=!talent.momentum.enabled&raid_event.movement.in>charges*10&(talent.demon_blades.enabled|buff.metamorphosis.down)
     if S.FelRush:IsCastable(20, true) and (not S.Momentum:IsAvailable() and (S.DemonBlades:IsAvailable() or Player:BuffDownP(S.MetamorphosisBuff))) then
-      if AR.Cast(S.FelRush) then return "FR Filler"; end
+      if AR.CastSuggested(S.FelRush) then return "FR Filler"; end
     end
     -- demons_bite
     if InMeleeRange and S.DemonsBite:IsCastable() then
@@ -385,7 +385,7 @@ local function APL()
     end
     -- fel_rush,if=movement.distance>15|(buff.out_of_range.up&!talent.momentum.enabled)
     if S.FelRush:IsCastable(20) and (not IsInMeleeRange() and not S.Momentum:IsAvailable()) then
-      if AR.Cast(S.FelRush) then return "FR OOR"; end
+      if AR.CastSuggested(S.FelRush) then return "FR OOR"; end
     end
     -- throw_glaive,if=!talent.bloodlet.enabled
     if S.ThrowGlaive:IsCastable(30) and (not S.Bloodlet:IsAvailable()) then

--- a/AethysRotation_DemonHunter/Settings.lua
+++ b/AethysRotation_DemonHunter/Settings.lua
@@ -4,7 +4,13 @@
   local addonName, addonTable = ...;
   -- AethysRotation
   local AR = AethysRotation;
-
+  
+  local AC = AethysCore;
+  -- File Locals
+  local GUI = AC.GUI;
+  local CreateChildPanel = GUI.CreateChildPanel;
+  local CreatePanelOption = GUI.CreatePanelOption;
+  local CreateARPanelOption = AR.GUI.CreateARPanelOption;
 
 --- ============================ CONTENT ============================
   -- All settings here should be moved into the GUI someday.
@@ -33,7 +39,27 @@
         -- Abilities
         ChaosBlades = {true, false},
         Metamorphosis = {true, false},
-        Nemesis = {true, false}
-      }
+        Nemesis = {true, false},
+      },
+	 
     }
   };
+
+  AR.GUI.LoadSettingsRecursively(AR.GUISettings);
+  local ARPanel = AR.GUI.Panel;
+  local CP_DemonHunter = CreateChildPanel(ARPanel, "DemonHunter");
+  local CP_Havoc = CreateChildPanel(CP_DemonHunter, "Havoc");
+  local CP_Vengeance = CreateChildPanel(CP_DemonHunter, "Vengeance");
+  
+  CreateARPanelOption("OffGCDasOffGCD", CP_DemonHunter, "APL.DemonHunter.Commons.OffGCDasOffGCD.Racials", "Racials");
+  CreateARPanelOption("OffGCDasOffGCD", CP_DemonHunter, "APL.DemonHunter.Commons.OffGCDasOffGCD.ConsumeMagic", "Consume Magic");
+  CreatePanelOption("CheckButton", CP_DemonHunter, "APL.DemonHunter.Commons.UseTrinkets", "Use Trinkets", "Use Trinkets as part of the rotation");
+  CreatePanelOption("CheckButton", CP_DemonHunter, "APL.DemonHunter.Commons.UsePotions", "Use Potions", "Use Potions as part of the rotation");
+  
+  CreateARPanelOption("OffGCDasOffGCD", CP_Vengeance, "APL.DemonHunter.Vengeance.OffGCDasOffGCD.DemonSpikes", "Demon Spikes");
+  CreateARPanelOption("OffGCDasOffGCD", CP_Vengeance, "APL.DemonHunter.Vengeance.OffGCDasOffGCD.InfernalStrike", "Infernal Strike");  
+  
+  CreateARPanelOption("OffGCDasOffGCD", CP_Havoc, "APL.DemonHunter.Havoc.OffGCDasOffGCD.ChaosBlades", "ChaosBlades");
+  CreateARPanelOption("OffGCDasOffGCD", CP_Havoc, "APL.DemonHunter.Havoc.OffGCDasOffGCD.Metamorphosis", "Metamorphosis");  
+  CreateARPanelOption("OffGCDasOffGCD", CP_Havoc, "APL.DemonHunter.Havoc.OffGCDasOffGCD.Nemesis", "Nemesis");  
+


### PR DESCRIPTION
When we are not using Fel Mastery or Momentum Fel Rush it is not necessary to have it in the main icon since it should never block the rotation as it does now. 

Having it as a suggestion enables us the save stacks for incoming movement or continuing with the rotation even when were in a place where movement is not prudent.